### PR TITLE
Add build-plugin to generate OSGI-headers

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -241,6 +241,36 @@
             <!-- endregion tests report -->
 
             <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <version>5.1.4</version>
+                <executions>
+                    <execution>
+                        <id>create-manifest</id>
+                        <goals>
+                            <goal>manifest</goal>
+                        </goals>
+                        <configuration>
+                            <instructions>
+                                <Export-Package>com.antkorwin.xsync</Export-Package>
+                                <_noextraheaders>true</_noextraheaders>
+                                <_snapshot>SNAPSHOT</_snapshot>
+                            </instructions>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>3.2.0</version>
+                <configuration>
+                    <archive>
+                        <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+                    </archive>
+                </configuration>
+            </plugin>
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
                 <version>2.2.1</version>


### PR DESCRIPTION
Bundle-maven-plugin generates minimal required headers needed for use in OSGI.